### PR TITLE
fix #64

### DIFF
--- a/PControl_Matlab/controller/dec2char.m
+++ b/PControl_Matlab/controller/dec2char.m
@@ -1,39 +1,38 @@
 function charArray = dec2char(num, num_chars)
 % this functions makes an array of char values (0-255) from a decimal number
 % this is listed in MSB first order.
-% untested for negative numbers, probably wrong!
+% Not working for negative numbers
 % to decode, for e.g. a 3 char array:
 % ans = charArray(1)*2^16 + charArray(2)*2^8 + charArray(3)*2^0
 % JL 2/2/2016 dec2char cannot handle negative numbers
 % FL 3/1/2022 fix constraint check to avoid overflow error
 % FL 3/16/2022 fix constraint with large num_chars
 % FL 3/17/2022 limit return type to uint8 with values 0..255
+% FL 8/4/2022 fix https://github.com/JaneliaSciComp/G4_Display_Tools/issues/64
 
 arguments % simple argument verification
     num (1,1) {mustBeInteger, mustBeGreaterThanOrEqual(num, 0)}
     num_chars (1,1) {mustBeGreaterThanOrEqual(num_chars, 0)}
 end
-% more difficult argument verification
-assert(num <  2^(8*num_chars), ...
-    "G4DT:dec2char:numchar",... 
-    "Not enough characters for a number of size %d (should be between 0...%d)", ...
-    num_chars, (2^(8*num_chars)-1))
-assert(2^(8*(num_chars-1)) ~= Inf,...
-    "G4DT:dec2char:overflow", ...
-    "the number of characters (%d) is too much for MATLAB to handle", num_chars);
-% end argument verification
+% % % % more difficult argument verification
+rnum = cast(num, 'uint64');
+assert(rnum == num, ...
+    "Rounding error. The number you are giving is too big. Try to use explicit typing instead, eg `dec2char(uint64(%u), %d)`", rnum, num_chars)
 
+% [f,e] = log2(num);
+% assert(e <= num_chars, ...
+%     "G4DT:dec2char:numchar",... 
+%     "Not enough characters for a number of size %d (%u should be between 0...%u)", ...
+%     num_chars, rnum, (uint64(2^(8*num_chars))-1))
+assert(rnum <  uint64(2^(8*num_chars)), ...
+   "G4DT:dec2char:numchar",... 
+   "Not enough characters for a number of size %d (%u should be between 0...%u)", ...
+   num_chars, rnum, (uint64(2^(8*num_chars))-1))
+
+bitArray = bitget(rnum, 64:-1:1, 'uint64');
 charArray = uint8(zeros(1,num_chars));
-num_rem = num;
-
-for j = num_chars:-1:1
-    temp = floor((num_rem)/(2^(8*(j-1))));
-    num_rem = num_rem - temp*(2^(8*(j-1)));
-    charArray(j) = temp;
+maxChars = min(num_chars, 8);
+for j = 0:1:maxChars-1
+    temp = bitArray(64-j*8-7:64-j*8);
+    charArray(j+1) = uint8(bin2dec(num2str(temp)));
 end
-
-
-
-
-
-    

--- a/PControl_Matlab/test_scripts/dec2charTest.m
+++ b/PControl_Matlab/test_scripts/dec2charTest.m
@@ -2,10 +2,12 @@ classdef dec2charTest < matlab.unittest.TestCase
 
     methods(Test, TestTags = {'DisplayToolsUtilities', 'helper'})
 
-        function validNumbers(testCase)
-            % Randomly test a subset of the acceptable dec2char argument space
+        function validUINT8NumbersLongStreamsNumbers(testCase)
+            %% Randomly test a subset of the acceptable dec2char argument space. 
+            %  Both, the tested value and the dimension are sampled from
+            %  within 'uint8' range.
             for i = randi([0 255], 1, 50)
-                for j = randi([1 128], 1, 50)
+                for j = randi([1 255], 1, 50)                    
                     expectedResult = uint8(zeros(1,j));
                     expectedResult(1) = i;
                     testCase.verifyEqual(dec2char(i, j), expectedResult, ...
@@ -14,23 +16,63 @@ classdef dec2charTest < matlab.unittest.TestCase
             end
         end
         
+        function validNumbers(testCase)
+            %% Calculates the bytestreams of different lengths for numbers in the range between 0 and 2^53-2. 
+            % Then reconstructs the original number from this and checks if that is correct.
+            for i = randi([0 flintmax-2], 1, 50)
+                minlength = ceil(log2(i)/8);
+                for j = randi([minlength 255], 1, 10)
+                    actualStream = dec2char(i, j);
+                    actualNumber = uint64(0);
+                    for k = 1:length(actualStream)
+                        addval = double(bitshift(uint64(actualStream(k)), (k-1)*8));
+                        actualNumber = actualNumber + addval;
+                    end
+                    testCase.verifyEqual(actualNumber, uint64(i), ...
+                        sprintf("dec2char produces the wrong stream for value %d and dimension %d", i, j));
+                end
+            end
+        end
+
+        function validNumbersBreakOlddec2char(testCase)
+            %% Most of these are numbers broke the previous dec2char function.
+            numbers = [   127     128     5000   5000     5000   intmax('uint32')];
+            types =   ["uint8" "uint8" "uint16" "int16" "uint16" "uint32"];
+            dimensions = [  2       2        2       2        3        4];
+            assert(length(numbers) == length(types),...
+                "Setup error: numbers and types correspond and have to have the same length");
+            assert(length(numbers) == length(dimensions),...
+                "Setup error: numbers and dimensions correspond and have to have the same length");
+            for i = 1:length(numbers)
+                number = numbers(i);
+                typedNumber = cast(numbers(i), types(i));
+                assert(number == typedNumber, ...
+                    "somehow %d and %d are not considered to be the same", number, typedNumber);
+                dimension = dimensions(i);
+                realStream = dec2char(typedNumber, dimension);
+                expectedStream = dec2char(number, dimension);
+                testCase.verifyEqual(realStream, expectedStream, ...
+                    sprintf("dec2char produces an error for value %d and dimension %d", number, dimension));
+            end
+        end
+
         function negativeNumbersFail(testCase)
-            for i = randi([-128 -1], 1, 10)
+            %% Make sure that negative numbers throw an exepeption
+            for i = randi([-flintmax+1 -1], 1, 100)
                 testCase.verifyError(@()dec2char(i, 1), 'MATLAB:validators:mustBeGreaterThanOrEqual');
             end
         end
-        
+
         function largeNumbersFail(testCase)
-            for i =  randi([256 65000], 1, 10)
-                testCase.verifyError(@()dec2char(i, 1), 'G4DT:dec2char:numchar');
+            %% Make sure that numbers larger than the dimensions necessary will throw an exception
+            for i =  randi([256 flintmax-1], 1, 100)
+                maxlength = ceil(log2(i)/8);
+                for j = randi([1 maxlength-1], 1, 10)
+                    testCase.verifyError(@()dec2char(i, j), 'G4DT:dec2char:numchar');
+                end
             end
         end
-        
-        function largeCharactersFail(testCase)
-            for i = randi([129 255], 1, 10)
-                testCase.verifyError(@()dec2char(1, i), 'G4DT:dec2char:overflow');
-            end
-        end
+                
     end
 
 end


### PR DESCRIPTION
Uses a different algorithm to calculate the byte stream. It fixes the issues described in #64.

Also update the `dec2charTest.m` to test for known errors and expand the tested space.